### PR TITLE
Implementing issue #3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Quick note: changes marked with [DEV] are only interested for hepshell developers.
 
 # master
+ - added `hepshell.settings` (see issue #3)
  - fixed issue #2: better `interpreter.call` for commands that require inputs
 
 # 0.1.5

--- a/examples/hepshell_settings.py
+++ b/examples/hepshell_settings.py
@@ -1,0 +1,8 @@
+
+'''
+    List of modules which should be loaded as commands for hepshell
+'''
+COMMANDS = [
+    'hepshell.commands',
+    'mymodule.commands',
+]

--- a/hepshell/__init__.py
+++ b/hepshell/__init__.py
@@ -14,7 +14,7 @@ if not 'HEP_PROJECT_ROOT' in os.environ:
     sys.exit(-1)
 HEP_PROJECT_ROOT = os.environ['HEP_PROJECT_ROOT']
 
-LOG = logging.getLogger(__name__)
+LOG = logging.getLogger('hepshell')
 LOG.setLevel(logging.DEBUG)
 # logging to a file
 formatter = logging.Formatter(
@@ -38,7 +38,15 @@ else:
 ch.setFormatter(formatter)
 LOG.addHandler(ch)
 
-from .interpreter import run_cli
-from .interpreter import run_command
+from . import interpreter
+run_cli = interpreter.run_cli
+run_command = interpreter.run_command
 
-__all__ = ['interpreter', 'run_cli', 'run_command']
+from . import settings as SETTINGS
+
+__all__ = [
+    'interpreter',
+    'run_cli',
+    'run_command',
+    'SETTINGS',
+]

--- a/hepshell/interpreter.py
+++ b/hepshell/interpreter.py
@@ -135,7 +135,20 @@ def __get_commands(command_paths):
 
     return commands, hierarchy
 
-COMMANDS, HIERARCHY = __get_commands(COMMAND_PATHS)
+
+def __get_command_paths():
+    from . import settings
+    for cmd in settings.COMMANDS:
+        try:
+            mod = import_module(cmd)
+        except ImportError:
+            LOG.error('Could not import {0}'.format(cmd))
+            continue
+        location = os.path.dirname(os.path.abspath(mod.__file__))
+        yield location
+
+
+COMMANDS, HIERARCHY = __get_commands(__get_command_paths())
 
 
 def __traverse(commands, tokens, incomplete, results=[]):

--- a/hepshell/settings.py
+++ b/hepshell/settings.py
@@ -1,0 +1,21 @@
+import os
+
+'''
+    List of modules which should be loaded as commands for hepshell
+'''
+COMMANDS = [
+    'hepshell.commands'
+]
+
+# load ENV variables as settings if available
+ENV_PREFIX = 'HEPSHELL_'
+for key in os.environ:
+    if key.startswith(ENV_PREFIX):
+        name = key[len(ENV_PREFIX):].upper()
+        globals()[name] = os.environ[key]
+
+# if hepshell_settings exists in PYTHONPATH import all definitions
+try:
+    from hepshell_settings import *
+except ImportError:
+    pass


### PR DESCRIPTION
This PR introduces the possibility to define a python configuration (settings) file as per #3.
This allows to load arbitrary modules as commands as long as they available in `PYTHONPATH`.

This PR breaks the existing mechanism through `HEP_PROJECT_BASE_MODULE`, `HEP_PROJECT_COMMANDS` and `HEP_PROJECT_COMMANDS`.

This PR will not be merged until the projects using hepshell have included the `hepshell_settings.py` file in their `PYTHONPATH` with the following content:

``` python
COMMANDS = [
    'hepshell.commands',
    'mymodule.commands',
]
```
