### PR TITLE
Automatically give arguments their default value if no value provided

### DIFF
--- a/hepshell/interpreter.py
+++ b/hepshell/interpreter.py
@@ -221,7 +221,7 @@ def _convert(value):
     return value
 
 
-def _parse_args(args):
+def _parse_args(args,command):
     PARAM_TOKEN = '--'
     positional_args = []
     parameters = {}
@@ -233,8 +233,9 @@ def _parse_args(args):
             arg = arg.lstrip(PARAM_TOKEN)
         if '=' in arg:
             name, value = arg.split('=')
-
             parameters[name] = _convert(value)
+        elif hasattr(command,"DEFAULTS") and arg in command.DEFAULTS:
+            parameters[arg]=command.DEFAULTS[arg]
         else:  # assume flag == True
             parameters[arg] = True
     return positional_args, parameters
@@ -281,12 +282,12 @@ def run_command(args):
         return
 
     command, arguments = _find_command_and_args(args)
-    parameters, variables = _parse_args(arguments)
-
     if command is None:
         LOG.error('Invalid command "{0}"'.format(args[0]))
         LOG.info('Known commands:\n' + '\n '.join(COMMANDS.keys()))
         return -1
+    parameters, variables = _parse_args(arguments,command)
+
 
     # log command
     # execute


### PR DESCRIPTION
Makes use of the Command class' DEFAULT dict (if it exists) to give default values to arguments called without a value. if the command doesn't have a  DEFAULT or if the argument is not listed there then the behaviour is as before.